### PR TITLE
Fix swaybar tray for non-systemd

### DIFF
--- a/include/swaybar/tray/tray.h
+++ b/include/swaybar/tray/tray.h
@@ -2,7 +2,7 @@
 #define _SWAYBAR_TRAY_TRAY_H
 
 #include "config.h"
-#ifdef HAVE_LIBSYSTEMD
+#if HAVE_LIBSYSTEMD
 #include <systemd/sd-bus.h>
 #elif HAVE_LIBELOGIND
 #include <elogind/sd-bus.h>


### PR DESCRIPTION
Meson's generated config.h header defines false macros as 0, not
undefined.  This means that the header line, which was checking for the
definition existing, not a non-zero value, was incorrect.  Now the
swaybar tray can be used with systemd, elogind, or basu.